### PR TITLE
Implement distributed training

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,8 +8,8 @@ import wandb
 from transformers.models.auto.modeling_auto import AutoModelForPreTraining
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
-from distributed import DistributedParameters, setup_ddp
 from src.config_to_dataclass import config_to_dataclass
+from src.distributed import DistributedParameters, setup_ddp
 from src.training import prepare_s2s_dataset
 from src.training.experiment_config import ExperimentConfig
 from src.training.train import train

--- a/run.py
+++ b/run.py
@@ -42,6 +42,7 @@ def run(
     model = AutoModelForPreTraining.from_pretrained(config.pretrained_model).to(
         distributed_parameters["device"]
     )
+    model.gradient_checkpointing_enable()
     if distributed_parameters["distributed"]:
         model = torch.nn.parallel.DistributedDataParallel(
             model, device_ids=[distributed_parameters["local_rank"]]

--- a/run.py
+++ b/run.py
@@ -1,34 +1,26 @@
 import argparse
-import os
 import pathlib
 import random
 from dataclasses import asdict
 
+
 import torch
+import wandb
 from transformers.models.auto.modeling_auto import AutoModelForPreTraining
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
-import wandb
 from src.config_to_dataclass import config_to_dataclass
 from src.training import prepare_s2s_dataset
 from src.training.experiment_config import ExperimentConfig
 from src.training.train import train
-
-device = (
-    "cuda"
-    if torch.cuda.is_available()
-    else ("mps" if torch.backends.mps.is_available() else "cpu")
-)
-print(f"Running on {device=}")
+from distributed import setup_ddp, DistributedParameters
 
 
-def _make_if_needed(path: str):
-    if not os.path.exists(path):
-        os.makedirs(path)
-    return path
-
-
-def run(config: ExperimentConfig, experiment_folder: pathlib.Path):
+def run(
+    config: ExperimentConfig,
+    experiment_folder: pathlib.Path,
+    distributed_parameters: DistributedParameters,
+):
     random.seed(0)
 
     # Initialize WandB experiment
@@ -46,79 +38,31 @@ def run(config: ExperimentConfig, experiment_folder: pathlib.Path):
 
     # Prepare model, dataset, tokenizer
     tokenizer = AutoTokenizer.from_pretrained(config.pretrained_model, use_fast=False)
-    model = AutoModelForPreTraining.from_pretrained(config.pretrained_model).to(device)
-
+    model = AutoModelForPreTraining.from_pretrained(config.pretrained_model).to(
+        distributed_parameters["device"]
+    )
+    ddp_model = torch.nn.parallel.DistributedDataParallel(
+        model, device_ids=[distributed_parameters["local_rank"]]
+    )
     if config.model_type == "seq2seq":
         dataloaders = prepare_s2s_dataset.create_dataloaders(
-            tokenizer=tokenizer, config=config
+            tokenizer=tokenizer,
+            config=config,
+            distributed_parameters=distributed_parameters,
         )
     else:
         raise NotImplementedError()
 
     # Training loop
     if config.mode in ["pretrain", "finetune"]:
-        model = train(
-            model,
+        ddp_model = train(
+            ddp_model,
             train_dataloader=dataloaders["train"],
             dev_dataloader=dataloaders["dev"],
             config=config,
             experiment_folder=experiment_folder,
-            device=device,
+            distributed_parameters=distributed_parameters,
         )
-
-    # args = transformers.Seq2SeqTrainingArguments(
-    #     output_dir=output_dir,
-    #     evaluation_strategy="epoch",
-    #     learning_rate=config.learning_rate,
-    #     per_device_train_batch_size=config.batch_size,
-    #     per_device_eval_batch_size=1,
-    #     eval_accumulation_steps=10,
-    #     gradient_accumulation_steps=64,
-    #     weight_decay=0.01,
-    #     save_strategy="epoch",
-    #     save_total_limit=10 if config.use_early_stopping else 3,
-    #     num_train_epochs=config.max_epochs,
-    #     predict_with_generate=True,
-    #     load_best_model_at_end=config.use_early_stopping,
-    #     logging_steps=100,
-    #     generation_max_length=1024,
-    #     generation_num_beams=3,
-    #     report_to="wandb",
-    #     metric_for_best_model="chrf++",
-    #     fp16=True,
-    #     dataloader_num_workers=4,
-    # )
-    # trainer = transformers.Seq2SeqTrainer(
-    #     model,
-    #     args,
-    #     optimizers=(optimizer, lr_scheduler),
-    #     data_collator=transformers.DataCollatorForSeq2Seq(
-    #         tokenizer, model=model, label_pad_token_id=tokenizer.pad_token_id
-    #     ),
-    #     train_dataset=dataset["train"],  # type:ignore
-    #     eval_dataset=dataset["eval"],  # type:ignore
-    #     compute_metrics=compute_metrics(tokenizer),
-    #     tokenizer=tokenizer,
-    #     callbacks=[
-    #         DelayedEarlyStoppingCallback(
-    #             early_stopping_patience=config.early_stopping_patience
-    #         )
-    #     ]
-    #     if config.use_early_stopping
-    #     else [],
-    # )
-
-    # if config.mode == "pretrain" or config.mode == "finetune":
-    #     print("Training...")
-    #     if config.checkpoint_path is not None:
-    #         print(f"Continuing training from {config.checkpoint_path}")
-    #     trainer.train(config.checkpoint_path)
-
-    #     if config.output_model_path is None:
-    #         raise ValueError("Must have an output path when training")
-    #     print(f"Saving model to {config.output_model_path}")
-    #     trainer.save_model(_make_if_needed(config.output_model_path))
-    #     print("Model saved!")
 
     # elif config.mode == "predict":
     #     print("Creating predictions...")
@@ -166,4 +110,5 @@ if __name__ == "__main__":
         dataclass_type=ExperimentConfig,
     )
     folder = pathlib.Path(args.config).parent
-    run(config, folder)
+    run(config=config, experiment_folder=folder, distributed_parameters=setup_ddp())
+    torch.distributed.destroy_process_group()

--- a/run.py
+++ b/run.py
@@ -3,17 +3,16 @@ import pathlib
 import random
 from dataclasses import asdict
 
-
 import torch
 import wandb
 from transformers.models.auto.modeling_auto import AutoModelForPreTraining
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
+from distributed import DistributedParameters, setup_ddp
 from src.config_to_dataclass import config_to_dataclass
 from src.training import prepare_s2s_dataset
 from src.training.experiment_config import ExperimentConfig
 from src.training.train import train
-from distributed import setup_ddp, DistributedParameters
 
 
 def run(

--- a/run_curc.sh
+++ b/run_curc.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 #SBATCH --nodes=1
-#SBATCH --gres=gpu:h100_3g.40gb
-#SBATCH --ntasks=10
-#SBATCH --mem-per-cpu=4000m
+#SBATCH --ntasks-per-node=3
+#SBATCH --gres=gpu:3
+#SBATCH --mem-per-cpu=4GB
+#SBATCH --cpus-per-task=4
 #SBATCH --time=7-00:00:00
-#SBATCH --qos=blanca-blast-lecs
-#SBATCH --partition=blanca-blast-lecs
-#SBATCH --account=blanca-blast-lecs
+#SBATCH --qos=blanca-curc-gpu
+#SBATCH --partition=blanca-curc-gpu
+#SBATCH --account=blanca-curc-gpu
 #SBATCH --out=logs/polygloss.%j.out
 #SBATCH --error=logs/polygloss.%j.err
 

--- a/run_curc.sh
+++ b/run_curc.sh
@@ -17,5 +17,3 @@ mamba activate polygloss
 cd "/projects/$USER/polygloss"
 
 python run.py "$1"
-
-# torchrun --nproc_per_node=4 run.py --config ../configs/pretrain_base.cfg

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -11,7 +11,7 @@
 #SBATCH --out=logs/polygloss.%j.out
 #SBATCH --error=logs/polygloss.%j.err
 
-export MASTER_PORT=$(expr 10000 + $(echo -n $SLURM_JOBID | tail -c 4) + $SLURM_ARRAY_TASK_ID)
+export MASTER_PORT=$((10000 + SLURM_JOB_ID % 50000))
 
 export WORLD_SIZE=$(($SLURM_NNODES * $SLURM_NTASKS_PER_NODE))
 echo "WORLD_SIZE="$WORLD_SIZE

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -8,8 +8,8 @@
 #SBATCH --qos=blanca-curc-gpu
 #SBATCH --partition=blanca-curc-gpu
 #SBATCH --account=blanca-curc-gpu
-#SBATCH --out=logs/polygloss.%j.out
-#SBATCH --error=logs/polygloss.%j.err
+#SBATCH --out=logs/%j.out
+#SBATCH --error=logs/%j.err
 
 export MASTER_PORT=$((10000 + SLURM_JOB_ID % 50000))
 

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -13,8 +13,8 @@
 
 export MASTER_PORT=$((10000 + SLURM_JOB_ID % 50000))
 export WORLD_SIZE=$(($SLURM_NNODES * $SLURM_NTASKS_PER_NODE))
-
 export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export PYTHONUNBUFFERED=1
 
 module purge
 module load miniforge

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=3
+#SBATCH --gres=gpu:3
+#SBATCH --mem-per-cpu=4GB
+#SBATCH --cpus-per-task=4
+#SBATCH --time=7-00:00:00
+#SBATCH --qos=blanca-curc-gpu
+#SBATCH --partition=blanca-curc-gpu
+#SBATCH --account=blanca-curc-gpu
+#SBATCH --out=logs/polygloss.%j.out
+#SBATCH --error=logs/polygloss.%j.err
+
+export MASTER_PORT=$(expr 10000 + $(echo -n $SLURM_JOBID | tail -c 4) + $SLURM_ARRAY_TASK_ID)
+
+export WORLD_SIZE=$(($SLURM_NNODES * $SLURM_NTASKS_PER_NODE))
+echo "WORLD_SIZE="$WORLD_SIZE
+
+master_addr=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export MASTER_ADDR=$master_addr
+echo "MASTER_ADDR="$MASTER_ADDR
+
+module purge
+module load miniforge
+mamba activate polygloss
+cd "/projects/$USER/polygloss"
+
+
+srun python run.py "$1"
+

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -13,6 +13,7 @@
 
 export MASTER_PORT=$((10000 + SLURM_JOB_ID % 50000))
 export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export OMP_NUM_THREADS=4
 export PYTHONUNBUFFERED=1
 
 module purge

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -12,7 +12,6 @@
 #SBATCH --error=logs/%j.err
 
 export MASTER_PORT=$((10000 + SLURM_JOB_ID % 50000))
-export WORLD_SIZE=$(($SLURM_NNODES * $SLURM_NTASKS_PER_NODE))
 export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
 export PYTHONUNBUFFERED=1
 

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -12,19 +12,19 @@
 #SBATCH --error=logs/%j.err
 
 export MASTER_PORT=$((10000 + SLURM_JOB_ID % 50000))
-
 export WORLD_SIZE=$(($SLURM_NNODES * $SLURM_NTASKS_PER_NODE))
-echo "WORLD_SIZE="$WORLD_SIZE
 
-master_addr=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
-export MASTER_ADDR=$master_addr
-echo "MASTER_ADDR="$MASTER_ADDR
+export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
 
 module purge
 module load miniforge
 mamba activate polygloss
 cd "/projects/$USER/polygloss"
 
-
-srun python run.py "$1"
-
+torchrun \
+  --nproc_per_node=$SLURM_NTASKS_PER_NODE \
+  --nnodes=$SLURM_NNODES \
+  --node_rank=$SLURM_NODEID \
+  --master_addr=$MASTER_ADDR \
+  --master_port=$MASTER_PORT \
+  run.py "$1"

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --nodes=3
+#SBATCH --nodes=1
 #SBATCH --ntasks-per-node=3
 #SBATCH --gres=gpu:3
 #SBATCH --mem-per-cpu=4GB

--- a/run_curc_ddp.sh
+++ b/run_curc_ddp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --nodes=1
+#SBATCH --nodes=3
 #SBATCH --ntasks-per-node=3
 #SBATCH --gres=gpu:3
 #SBATCH --mem-per-cpu=4GB

--- a/src/config_to_dataclass.py
+++ b/src/config_to_dataclass.py
@@ -20,6 +20,9 @@ def config_to_dataclass(config_path: str, overrides: str, dataclass_type: Type[T
     if not is_dataclass(dataclass_type):
         raise TypeError(f"{dataclass_type.__name__} must be a dataclass type")
 
+    if not config_path:
+        raise ValueError("Must provide a config file!")
+
     config = configparser.ConfigParser()
     config.read(config_path)
 
@@ -44,7 +47,7 @@ def config_to_dataclass(config_path: str, overrides: str, dataclass_type: Type[T
                 value = float(overrides_dict[field.name])
             elif is_literal:
                 value = overrides_dict[field.name]
-                if value not in literal_values:
+                if value not in literal_values:  # type:ignore
                     raise ValueError(
                         f"Value '{value}' not in allowed literals {literal_values}"
                     )

--- a/src/distributed.py
+++ b/src/distributed.py
@@ -42,7 +42,11 @@ def setup_ddp() -> DistributedParameters:
         }
     else:
         # Single GPU setup
-        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        device = torch.device(
+            "cuda"
+            if torch.cuda.is_available()
+            else ("mps" if torch.backends.mps.is_available() else "cpu")
+        )
         return {
             "world_size": 1,
             "rank": 0,

--- a/src/distributed.py
+++ b/src/distributed.py
@@ -51,6 +51,6 @@ def setup_ddp() -> DistributedParameters:
             "rank": 0,
             "local_rank": 0,
             "device": device,
-            "device_type": device,
+            "device_type": str(device),
             "distributed": False,
         }

--- a/src/distributed.py
+++ b/src/distributed.py
@@ -10,6 +10,7 @@ class DistributedParameters(TypedDict):
     rank: int
     local_rank: int
     device: torch.device
+    device_type: str
     distributed: bool
 
 
@@ -35,6 +36,7 @@ def setup_ddp() -> DistributedParameters:
             "rank": rank,
             "local_rank": local_rank,
             "device": device,
+            "device_type": "cuda",
             "distributed": True,
         }
     else:
@@ -49,5 +51,6 @@ def setup_ddp() -> DistributedParameters:
             "rank": 0,
             "local_rank": 0,
             "device": device,
+            "device_type": device,
             "distributed": False,
         }

--- a/src/distributed.py
+++ b/src/distributed.py
@@ -10,27 +10,43 @@ class DistributedParameters(TypedDict):
     rank: int
     local_rank: int
     device: torch.device
+    distributed: bool
 
 
 def setup_ddp() -> DistributedParameters:
-    rank = int(os.environ["SLURM_PROCID"])
-    world_size = int(os.environ["WORLD_SIZE"])
-    gpus_per_node = int(os.environ["SLURM_GPUS_ON_NODE"])
-    assert gpus_per_node == torch.cuda.device_count()
-    print(
-        f"Hello from rank {rank} of {world_size} on {gethostname()} where there are"
-        f" {gpus_per_node} allocated GPUs per node.",
-        flush=True,
-    )
-    torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
-    if rank == 0:
-        print(f"Group initialized? {torch.distributed.is_initialized()}", flush=True)
-    local_rank = rank - gpus_per_node * (rank // gpus_per_node)
-    device = torch.device(f"cuda:{local_rank}")
-    torch.cuda.set_device(device)
-    return {
-        "world_size": world_size,
-        "rank": rank,
-        "local_rank": local_rank,
-        "device": device,
-    }
+    if "WORLD_SIZE" in os.environ and "SLURM_PROCID" in os.environ:
+        # Distributed
+        rank = int(os.environ["SLURM_PROCID"])
+        world_size = int(os.environ["WORLD_SIZE"])
+        gpus_per_node = int(os.environ["SLURM_GPUS_ON_NODE"])
+        assert gpus_per_node == torch.cuda.device_count()
+        print(
+            f"Hello from rank {rank} of {world_size} on {gethostname()} where there are"
+            f" {gpus_per_node} allocated GPUs per node.",
+            flush=True,
+        )
+        torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
+        if rank == 0:
+            print(
+                f"Group initialized? {torch.distributed.is_initialized()}", flush=True
+            )
+        local_rank = rank - gpus_per_node * (rank // gpus_per_node)
+        device = torch.device(f"cuda:{local_rank}")
+        torch.cuda.set_device(device)
+        return {
+            "world_size": world_size,
+            "rank": rank,
+            "local_rank": local_rank,
+            "device": device,
+            "distributed": True,
+        }
+    else:
+        # Single GPU setup
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        return {
+            "world_size": 1,
+            "rank": 0,
+            "local_rank": 0,
+            "device": device,
+            "distributed": False,
+        }

--- a/src/distributed.py
+++ b/src/distributed.py
@@ -1,0 +1,36 @@
+import os
+from socket import gethostname
+from typing import TypedDict
+
+import torch
+
+
+class DistributedParameters(TypedDict):
+    world_size: int
+    rank: int
+    local_rank: int
+    device: torch.device
+
+
+def setup_ddp() -> DistributedParameters:
+    rank = int(os.environ["SLURM_PROCID"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    gpus_per_node = int(os.environ["SLURM_GPUS_ON_NODE"])
+    assert gpus_per_node == torch.cuda.device_count()
+    print(
+        f"Hello from rank {rank} of {world_size} on {gethostname()} where there are"
+        f" {gpus_per_node} allocated GPUs per node.",
+        flush=True,
+    )
+    torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
+    if rank == 0:
+        print(f"Group initialized? {torch.distributed.is_initialized()}", flush=True)
+    local_rank = rank - gpus_per_node * (rank // gpus_per_node)
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    return {
+        "world_size": world_size,
+        "rank": rank,
+        "local_rank": local_rank,
+        "device": device,
+    }

--- a/src/training/experiment_config.py
+++ b/src/training/experiment_config.py
@@ -18,42 +18,64 @@ _glotto_to_iso = {
 
 @dataclass
 class ExperimentConfig:
-    """
-    Args:
-        mode ("pretrain", "finetune", "predict"): The mode to run in
-        pretrained_model (str): The name of the pretrained model to train or predict with
-        ft_glottocode (str, optional): The language to use for finetuning/prediction
-        max_epochs (int): Maximum number of training epochs
-        early_stopping_patience (int): Number of epochs with no improvement after which training is stopped
-        exclude_st_seg (bool): If True, excludes the segmented training data for the evaluation languages
-        use_translation (bool): If True, include the translation in the prompt
-        output_model_path (str): The path to output the model to
-        checkpoint_path (str, optional): The path to the checkpoint file when continuing training
-        checkpoint_save_dir (str): Directory where checkpoints will be saved
-    """
-
+    # ============================
     # General
+    # ============================
+
     mode: TRAIN_MODE
+    """Training mode: 'pretrain' for pretraining on all data, 'finetune' for language-specific finetuning,
+    or 'predict' for generating predictions on test data"""
+
     pretrained_model: str = "google/byt5-base"
+    """Hugging Face model identifier for the pretrained model to use"""
+
     model_type: MODEL_TYPE = "seq2seq"
+    """Architecture type: 'seq2seq' for encoder-decoder models or 'decoder' for decoder-only models"""
 
     # Dataset
     dataset_key: str = "lecslab/polygloss-corpus"
+    """Hugging Face dataset identifier for the corpus to use"""
+
     ft_glottocode: str | None = None
+    """Glottocode of the language to finetune on (None for pretraining on all languages)"""
+
     segmented_transcription: bool = True
+    """Whether to include examples with segmented transcriptions as input"""
+
     unsegmented_transcription: bool = True
+    """Whether to include examples with unsegmented transcriptions as input"""
+
     exclude_st_segmented: bool = False
+    """Whether to exclude segmented examples from the SIGMORPHON shared task"""
+
     create_segmentation_examples: bool = False
+    """Whether to create examples for the segmentation task (transcription → segmentation)"""
+
     use_translation: bool = True
+    """Whether to include translations in the input prompts when available"""
 
+    # ============================
     # Training
-    max_epochs: int = 50
-    use_early_stopping: bool = True
-    early_stopping_patience: int = 3
-    learning_rate: float = 5e-5
-    batch_size: int = 64
+    # ============================
 
+    max_epochs: int = 50
+    """Maximum number of training epochs"""
+
+    use_early_stopping: bool = True
+    """Whether to use early stopping based on validation performance"""
+
+    early_stopping_patience: int = 3
+    """Number of epochs with no improvement after which training will be stopped"""
+
+    learning_rate: float = 5e-5
+    """Learning rate for the optimizer"""
+
+    batch_size: int = 64  # per gpu
+    """Batch size per GPU for training and evaluation"""
+
+    # ============================
     # Computed properties
+    # ============================
     @property
     def ft_isocode(self):
         if self.ft_glottocode is not None:

--- a/src/training/prepare_s2s_dataset.py
+++ b/src/training/prepare_s2s_dataset.py
@@ -79,7 +79,6 @@ def create_dataloaders(
         batched=True,
         remove_columns=["input", "label"],
     )
-
     collator = DataCollatorForSeq2Seq(
         tokenizer, label_pad_token_id=typing.cast(int, tokenizer.pad_token_id)
     )

--- a/src/training/prepare_s2s_dataset.py
+++ b/src/training/prepare_s2s_dataset.py
@@ -103,15 +103,13 @@ def create_dataloaders(
                 if split == "train"
                 else SequentialSampler(dataset[split])
             )
-        dataloaders[split] = (
-            DataLoader(
-                dataset[split],  # type:ignore
-                batch_size=config.batch_size,
-                collate_fn=collator,
-                sampler=sampler,
-                num_workers=num_workers,
-                pin_memory=True,
-            ),
+        dataloaders[split] = DataLoader(
+            dataset[split],  # type:ignore
+            batch_size=config.batch_size,
+            collate_fn=collator,
+            sampler=sampler,
+            num_workers=num_workers,
+            pin_memory=True,
         )
     return dataloaders
 

--- a/src/training/prepare_s2s_dataset.py
+++ b/src/training/prepare_s2s_dataset.py
@@ -14,7 +14,7 @@ from torch.utils.data.distributed import DistributedSampler
 from transformers.data.data_collator import DataCollatorForSeq2Seq
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
-from distributed import DistributedParameters
+from src.distributed import DistributedParameters
 from src.training.experiment_config import ExperimentConfig
 
 

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -93,19 +93,21 @@ def train(
 
             # Sum losses over devices, if distributed
             if distributed_parameters["distributed"]:
-                train_loss_tensor = torch.tensor(train_loss)
+                train_loss_tensor = torch.tensor(train_loss, device=device)
                 torch.distributed.all_reduce(
                     train_loss_tensor, torch.distributed.ReduceOp.SUM
                 )
                 train_loss = (
-                    train_loss_tensor.item() / distributed_parameters["world_size"]
+                    train_loss_tensor.detach().item()
+                    / distributed_parameters["world_size"]
                 )
-                eval_loss_tensor = torch.tensor(eval_loss)
+                eval_loss_tensor = torch.tensor(eval_loss, device=device)
                 torch.distributed.all_reduce(
                     eval_loss_tensor, torch.distributed.ReduceOp.SUM
                 )
                 eval_loss = (
-                    eval_loss_tensor.item() / distributed_parameters["world_size"]
+                    eval_loss_tensor.detach().item()
+                    / distributed_parameters["world_size"]
                 )
             # Log results
             print(f"Epoch {epoch}\tLoss: {train_loss}\tEval loss: {eval_loss}")

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -2,11 +2,11 @@ import pathlib
 
 import torch
 import tqdm
+import wandb
 from torch.utils.data import DataLoader
 
-import wandb
-from src.training.experiment_config import ExperimentConfig
 from distributed import DistributedParameters
+from src.training.experiment_config import ExperimentConfig
 
 
 def train(

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -48,11 +48,8 @@ def train(
         optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         start_epoch = checkpoint["epoch"]
 
-    model.gradient_checkpointing_enable()
     scaler = torch.amp.grad_scaler.GradScaler()
-
     print(f"Training with {len(train_dataloader)} batches of size {config.batch_size}.")
-
     for epoch in range(start_epoch, config.max_epochs):
         if isinstance(train_dataloader.sampler, torch.utils.data.DistributedSampler):
             train_dataloader.sampler.set_epoch(epoch)  # type:ignore

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -5,7 +5,7 @@ import tqdm
 import wandb
 from torch.utils.data import DataLoader
 
-from distributed import DistributedParameters
+from src.distributed import DistributedParameters
 from src.training.experiment_config import ExperimentConfig
 
 

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -63,7 +63,9 @@ def train(
         for batch in train_dataloader:
             batch = {k: v.to(device) for k, v in batch.items()}
             optimizer.zero_grad()
-            with torch.amp.autocast_mode.autocast("cuda", dtype=torch.bfloat16):
+            with torch.amp.autocast_mode.autocast(
+                distributed_parameters["device_type"], dtype=torch.bfloat16
+            ):
                 out = model(**batch)
                 loss = _get_loss(out, batch["labels"])
             scaler.scale(loss).backward()
@@ -79,7 +81,9 @@ def train(
             # Eval step
             print("Evaluating...")
             with (
-                torch.amp.autocast_mode.autocast("cuda", dtype=torch.bfloat16),
+                torch.amp.autocast_mode.autocast(
+                    distributed_parameters["device_type"], dtype=torch.bfloat16
+                ),
                 torch.inference_mode(),
             ):
                 model.eval()


### PR DESCRIPTION
Adds support for distributed data parallel training (DDP) on one or more nodes.

DDP will automatically run when the `RANK` and `WORLD_SIZE` environment properties are detected. See the slurm script `run_curc_ddp.sh` for an example using `torchrun`, which automatically sets these properties.

Otherwise, training should still work fine on a single GPU.