### PR TITLE
Fix glossing version and add grad norm parameter

### DIFF
--- a/experiments/base_igt/pretrain.cfg
+++ b/experiments/base_igt/pretrain.cfg
@@ -9,6 +9,6 @@ exclude_st_seg = false
 use_translation = true
 
 # Training
-max_epochs = 25
+max_epochs = 50
 learning_rate = 5e-5
 batch_size = 24

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 datasets==3.5.0
 editdistance==0.8.1
-glossing>=1.0.1
+glossing>=1.0.2
 huggingface-hub>=0.19.4
 iso639_lang==2.6.1
 langid==1.1.6

--- a/src/config/experiment_config.py
+++ b/src/config/experiment_config.py
@@ -74,6 +74,9 @@ class ExperimentConfig:
     weight_decay: float = 0.01
     """Weight decay for the optimizer"""
 
+    grad_norm: float = 20.0
+    """Max gradient norm"""
+
     batch_size: int = 64  # per gpu
     """Batch size per GPU for training and evaluation"""
 

--- a/src/train.py
+++ b/src/train.py
@@ -94,7 +94,9 @@ def train(
                 loss = _get_loss(out, batch["labels"])
             scaler.scale(loss).backward()
             scaler.unscale_(optimizer)
-            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            torch.nn.utils.clip_grad_norm_(
+                model.parameters(), max_norm=config.grad_norm
+            )
             scaler.step(optimizer)
             scaler.update()
 


### PR DESCRIPTION
Updates to a fixed version of the `glossing` package (which fixes some eval bugs)
Also adds a settable `grad_norm` parameter.