### PR TITLE
readme.md: fix typo in usage example as well as accurately reflect execution result

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ lang = "Uspanteco"
 metalang = "Spanish"
 
 output = model.predict_igt(transcription, translation, lang, metalang)
-print(outputs) # CONJ(o) sea(sey) COM(x)-buscar(tok) E3S(r)-esposa(ixoqiil)
+print(output) # o(o) sea(sey) COM(x)-buscar(tok) E3S(r)-esposa(ixoqiil)
 ```
 
 ## License


### PR DESCRIPTION
In my execution of the model `CONJ(o)` is not the output.  I'm not sure if this is an error on the part of the model as I have no knowledge of Uspanteco, but the example does not accurately reflect what is actually output when run 